### PR TITLE
fix .gitgnore handling of __pycache__ subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 build/
 
 #ignore pycache
-pycache/*
+__pycache__/
+


### PR DESCRIPTION
Po mergu użyj komendy: `git rm --cached */__pycache__/*` aby usunąć wszelkie pozostałe niepożądane podfoldery  
fixes #34  